### PR TITLE
refactor: use theme variables for gradients

### DIFF
--- a/app/auth/check-email/page.tsx
+++ b/app/auth/check-email/page.tsx
@@ -5,11 +5,11 @@ import { Mail } from "lucide-react"
 
 export default function CheckEmailPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-orange-50 to-red-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[hsl(var(--color-primary)/0.1)] via-[hsl(var(--color-accent)/0.1)] to-[hsl(var(--color-destructive)/0.1)] p-4">
       <div className="w-full max-w-md">
         <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
           <CardHeader className="text-center space-y-4">
-            <div className="mx-auto w-16 h-16 bg-gradient-to-r from-blue-600 to-orange-500 rounded-full flex items-center justify-center">
+            <div className="mx-auto w-16 h-16 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-full flex items-center justify-center">
               <Mail className="w-8 h-8 text-white" />
             </div>
             <CardTitle className="text-2xl font-semibold text-gray-900">Check your email</CardTitle>

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -44,11 +44,11 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-orange-50 to-red-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[hsl(var(--color-primary)/0.1)] via-[hsl(var(--color-accent)/0.1)] to-[hsl(var(--color-destructive)/0.1)] p-4">
       <div className="w-full max-w-md">
         <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
           <CardHeader className="text-center space-y-2">
-            <div className="mx-auto w-12 h-12 bg-gradient-to-r from-blue-600 to-orange-500 rounded-xl flex items-center justify-center mb-4">
+            <div className="mx-auto w-12 h-12 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-xl flex items-center justify-center mb-4">
               <span className="text-white font-bold text-xl">MP</span>
             </div>
             <CardTitle className="text-2xl font-semibold text-gray-900">Welcome back</CardTitle>
@@ -89,7 +89,7 @@ export default function LoginPage() {
               )}
               <Button
                 type="submit"
-                className="w-full h-11 bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600 text-white font-medium"
+                className="w-full h-11 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))] text-white font-medium"
                 disabled={isLoading}
               >
                 {isLoading ? "Signing in..." : "Sign in"}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -61,11 +61,11 @@ export default function SignUpPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-orange-50 to-red-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[hsl(var(--color-primary)/0.1)] via-[hsl(var(--color-accent)/0.1)] to-[hsl(var(--color-destructive)/0.1)] p-4">
       <div className="w-full max-w-md">
         <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
           <CardHeader className="text-center space-y-2">
-            <div className="mx-auto w-12 h-12 bg-gradient-to-r from-blue-600 to-orange-500 rounded-xl flex items-center justify-center mb-4">
+            <div className="mx-auto w-12 h-12 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-xl flex items-center justify-center mb-4">
               <span className="text-white font-bold text-xl">MP</span>
             </div>
             <CardTitle className="text-2xl font-semibold text-gray-900">Create your account</CardTitle>
@@ -134,7 +134,7 @@ export default function SignUpPage() {
               )}
               <Button
                 type="submit"
-                className="w-full h-11 bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600 text-white font-medium"
+                className="w-full h-11 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))] text-white font-medium"
                 disabled={isLoading}
               >
                 {isLoading ? "Creating account..." : "Create account"}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -47,7 +47,7 @@ export default async function DashboardPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center gap-2">
-              <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-orange-500 rounded-lg flex items-center justify-center">
+              <div className="w-8 h-8 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">MP</span>
               </div>
               <span className="font-bold text-xl text-foreground">Ireal</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ export default async function HomePage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center gap-2">
-              <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-orange-500 rounded-lg flex items-center justify-center">
+              <div className="w-8 h-8 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">MP</span>
               </div>
               <span className="font-bold text-xl text-foreground">Ireal</span>
@@ -54,7 +54,7 @@ export default async function HomePage() {
               </Button>
               <Button
                 asChild
-                className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600"
+                className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]"
               >
                 <Link href="/auth/signup">Get Started</Link>
               </Button>
@@ -66,7 +66,7 @@ export default async function HomePage() {
       {/* Hero Section */}
       <section className="relative overflow-hidden">
         {/* Gradient Background */}
-        <div className="absolute inset-0 bg-gradient-to-br from-blue-600/10 via-orange-500/10 to-red-500/10" />
+        <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--color-primary)/0.1)] via-[hsl(var(--color-accent)/0.1)] to-[hsl(var(--color-destructive)/0.1)]" />
 
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16">
           <div className="text-center">
@@ -77,7 +77,7 @@ export default async function HomePage() {
 
             <h1 className="text-4xl md:text-6xl font-bold text-foreground mb-6 font-sans">
               Autogestiona tus{" "}
-              <span className="bg-gradient-to-r from-blue-600 via-orange-500 to-red-500 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-[hsl(var(--color-primary))] via-[hsl(var(--color-accent))] to-[hsl(var(--color-destructive))] bg-clip-text text-transparent">
                 Planes de Medios
               </span>{" "}
               con IA
@@ -91,7 +91,7 @@ export default async function HomePage() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button
                 size="lg"
-                className="bg-gradient-to-r from-blue-600 via-orange-500 to-red-500 hover:opacity-90 text-white"
+                className="bg-gradient-to-r from-[hsl(var(--color-primary))] via-[hsl(var(--color-accent))] to-[hsl(var(--color-destructive))] hover:opacity-90 text-white"
                 asChild
               >
                 <Link href="/auth/signup">
@@ -206,7 +206,7 @@ export default async function HomePage() {
           </p>
           <Button
             size="lg"
-            className="bg-gradient-to-r from-blue-600 via-orange-500 to-red-500 hover:opacity-90 text-white"
+            className="bg-gradient-to-r from-[hsl(var(--color-primary))] via-[hsl(var(--color-accent))] to-[hsl(var(--color-destructive))] hover:opacity-90 text-white"
             asChild
           >
             <Link href="/auth/signup">

--- a/app/workspace/[id]/calendar/page.tsx
+++ b/app/workspace/[id]/calendar/page.tsx
@@ -224,7 +224,7 @@ export default function CalendarPage({ params }: { params: { id: string } }) {
                 <option value="twitter">Twitter</option>
                 <option value="tiktok">TikTok</option>
               </select>
-              <Button className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600">
+              <Button className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]">
                 <Plus className="w-4 h-4 mr-2" />
                 New Content
               </Button>

--- a/app/workspace/[id]/page.tsx
+++ b/app/workspace/[id]/page.tsx
@@ -54,7 +54,7 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center gap-4">
               <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-orange-500 rounded-lg flex items-center justify-center">
+                <div className="w-8 h-8 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-lg flex items-center justify-center">
                   <span className="text-white font-bold text-sm">MP</span>
                 </div>
                 <div>
@@ -91,7 +91,7 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
                 </Link>
               </Button>
               <Button
-                className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600"
+                className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]"
                 asChild
               >
                 <Link href={`/workspace/${workspace.id}/campaigns/new`}>
@@ -141,7 +141,7 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-2xl font-semibold text-foreground">Campaigns</h2>
             <Button
-              className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600"
+              className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]"
               asChild
             >
               <Link href={`/workspace/${workspace.id}/campaigns/new`}>

--- a/app/workspace/[id]/social/page.tsx
+++ b/app/workspace/[id]/social/page.tsx
@@ -167,7 +167,7 @@ export default function SocialMediaPage({ params }: { params: { id: string } }) 
             </div>
             <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
               <DialogTrigger asChild>
-                <Button className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600">
+                <Button className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]">
                   <Plus className="w-4 h-4 mr-2" />
                   Add Connection
                 </Button>
@@ -330,7 +330,7 @@ export default function SocialMediaPage({ params }: { params: { id: string } }) 
               </p>
               <Button
                 onClick={() => setShowAddDialog(true)}
-                className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600"
+                className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]"
               >
                 <Plus className="w-4 h-4 mr-2" />
                 Add Your First Connection

--- a/app/workspace/standalone/page.tsx
+++ b/app/workspace/standalone/page.tsx
@@ -65,7 +65,7 @@ export default function StandaloneWorkspacePage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center gap-4">
-              <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-orange-500 rounded-lg flex items-center justify-center">
+              <div className="w-8 h-8 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">MP</span>
               </div>
               <div>
@@ -153,7 +153,7 @@ export default function StandaloneWorkspacePage() {
           <TabsContent value="campaigns" className="space-y-6">
             <div className="flex justify-between items-center">
               <h3 className="text-xl font-semibold">Mis Campañas</h3>
-              <Button className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600">
+              <Button className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]">
                 <Plus className="w-4 h-4 mr-2" />
                 Nueva Campaña con IA
               </Button>
@@ -244,7 +244,7 @@ export default function StandaloneWorkspacePage() {
                 <Card key={index}>
                   <CardContent className="p-4">
                     <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 bg-gradient-to-r from-blue-600 to-orange-500 rounded-full flex items-center justify-center text-white font-semibold">
+                      <div className="w-10 h-10 bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] rounded-full flex items-center justify-center text-white font-semibold">
                         {member.avatar}
                       </div>
                       <div>

--- a/components/workspace/create-workspace-dialog.tsx
+++ b/components/workspace/create-workspace-dialog.tsx
@@ -74,7 +74,7 @@ export function CreateWorkspaceDialog({ userId, onWorkspaceCreated }: CreateWork
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button className="bg-gradient-to-r from-blue-600 to-orange-500 hover:from-blue-700 hover:to-orange-600">
+        <Button className="bg-gradient-to-r from-[hsl(var(--color-primary))] to-[hsl(var(--color-accent))] hover:from-[hsl(var(--color-primary))] hover:to-[hsl(var(--color-accent))]">
           <Plus className="w-4 h-4 mr-2" />
           New Workspace
         </Button>


### PR DESCRIPTION
## Summary
- replace hard-coded gradient colors with CSS variables across app pages and components
- align auth and workspace buttons/backgrounds with theme palette

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68b5e4de92dc8332967027b08b10595c